### PR TITLE
Fix ECS agent logging

### DIFF
--- a/src/files/confd/templates/awslogs.conf.tmpl
+++ b/src/files/confd/templates/awslogs.conf.tmpl
@@ -22,10 +22,12 @@ datetime_format = %Y-%m-%dT%H:%M:%S.%f
 file = /var/log/ecs/ecs-init.log*
 log_group_name = {{ getv "/stack/name" }}/ec2/{{ getv "/autoscaling/group" }}/var/log/ecs/ecs-init
 log_stream_name = {instance_id}
-datetime_format = %Y-%m-%dT%H:%M:%
+datetime_format = %Y-%m-%dT%H:%M:%SZ
+time_zone = UTC
 
 [/var/log/ecs/ecs-agent.log]
 file = /var/log/ecs/ecs-agent.log*
 log_group_name = {{ getv "/stack/name" }}/ec2/{{ getv "/autoscaling/group" }}/var/log/ecs/ecs-agent
 log_stream_name = {instance_id}
 datetime_format = %Y-%m-%dT%H:%M:%SZ
+time_zone = UTC


### PR DESCRIPTION
I have discovered an issue where ECS agent logs are not being picked up by the CloudWatch logs agent.

I found I could fix this by forcing the time zone to UTC.

I also noticed an error in the timezone formate for the ECS init logs.

See http://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html for more details on CloudWatch logs agent configuration options.